### PR TITLE
Fix goroutine leaks in TestNodeProposeAddLearnerNode

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -860,6 +860,7 @@ func TestNodeProposeAddLearnerNode(t *testing.T) {
 	<-applyConfChan
 	close(stop)
 	<-done
+	n.Stop()
 }
 
 func TestAppendPagination(t *testing.T) {


### PR DESCRIPTION
The goroutine created with `n.run()` will leak if we forget to call `n.Stop()`
